### PR TITLE
fix: Add link to avto-dev/open-rpc-docs-builder-docker

### DIFF
--- a/src/docs/use.md
+++ b/src/docs/use.md
@@ -34,3 +34,4 @@ You can follow the guides [here](/developers/) and use the OpenRPC tools to crea
 - [ethernodeio/EnOS-Playground](https://github.com/ethernodeio/EnOS-Playground)
 - [etclabscore/jade-signer-rpc](https://github.com/etclabscore/jade-signer-rpc)
 - [multi-geth/multi-geth](https://github.com/multi-geth/multi-geth#openrpc-discovery)
+- [avto-dev/open-rpc-docs-builder-docker](https://github.com/avto-dev/open-rpc-docs-builder-docker)


### PR DESCRIPTION
Add a link at the invitation of @BelfordZ.
https://github.com/avto-dev/open-rpc-docs-builder-docker/issues/1#issue-557088747

resolve #115 
resolve https://github.com/avto-dev/open-rpc-docs-builder-docker/issues/1
