### PR TITLE
fix(footer): add gitter chat link

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -57,6 +57,10 @@ module.exports = {
         link: 'https://twitter.com/open_rpc'
       },
       {
+        name: 'Gitter Chat',
+        link: 'https://gitter.im/open-rpc/community'
+      },
+      {
         name: 'Github',
         link: 'https://github.com/open-rpc'
       }


### PR DESCRIPTION
adding gitter chat link to have another place other than github issues to discuss OpenRPC.

fixes #229
fixes #4 