### PR TITLE
fix(use): add docker image openrpc validator

### DIFF
--- a/src/docs/use.md
+++ b/src/docs/use.md
@@ -35,3 +35,4 @@ You can follow the guides [here](/developers/) and use the OpenRPC tools to crea
 - [etclabscore/jade-signer-rpc](https://github.com/etclabscore/jade-signer-rpc)
 - [multi-geth/multi-geth](https://github.com/multi-geth/multi-geth#openrpc-discovery)
 - [avto-dev/open-rpc-docs-builder-docker](https://github.com/avto-dev/open-rpc-docs-builder-docker)
+- [512k/openrpc-validator-docker](https://github.com/512k/openrpc-validator-docker)


### PR DESCRIPTION
## Docker image with CLI open-rpc validator

Validate an OpenRPC json document using docker

Repo: https://github.com/512k/openrpc-validator-docker