### PR TITLE
docs: include a reference to a CLI making use of OpenRPC

### DIFF
--- a/src/docs/use.md
+++ b/src/docs/use.md
@@ -36,3 +36,4 @@ You can follow the guides [here](/developers/) and use the OpenRPC tools to crea
 - [multi-geth/multi-geth](https://github.com/multi-geth/multi-geth#openrpc-discovery)
 - [avto-dev/open-rpc-docs-builder-docker](https://github.com/avto-dev/open-rpc-docs-builder-docker)
 - [512k/openrpc-validator-docker](https://github.com/512k/openrpc-validator-docker)
+- [json-rpc-shell](https://git.janouch.name/p/json-rpc-shell)


### PR DESCRIPTION
While for now the shell only cares to query "rpc.discover" (or read an OpenRPC document by file) when given the `-O` switch, it seems to be relevant. Also included is a test server application that implements the "rpc.discover" method.

Feel free to reject, as the software isn't fully invested in OpenRPC yet, not only because it's fairly limited by the libraries in use.

I plan to have it output syntax-highlighted examples for the currently entered method upon request ([local issue](https://git.janouch.name/p/json-rpc-shell/issues/2)).