### PR TITLE
Fix broken internal documentation links and GitHub repository URLs

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -73,7 +73,7 @@ export default async function RootLayout({
         <Layout
           navbar={navbar}
           pageMap={await getPageMap()}
-          docsRepositoryBase="https://github.com/open-rpc/website"
+          docsRepositoryBase="https://github.com/open-rpc/website/tree/master"
           footer={footer}
         >
           {children}

--- a/src/content/beginners.mdx
+++ b/src/content/beginners.mdx
@@ -33,9 +33,9 @@ The OpenRPC created in the previous example has provided a well documented API a
 
 - Examine the JSON-RPC 2.0 Specification [jsonrpc.org](https://www.jsonrpc.org/specification)
 - Read the OpenRPC Specification. [spec.open-rpc.org](http://spec.open-rpc.org#introduction)
-- Explore the Getting Started Guide. [open-rpc.org/getting-started](/getting-started/)
-- Want to get started using OpenRPC? [open-rpc.org/use](/use/)
-- Curious to learn more about OpenRPC and its technology? [open-rpc.org/learn](/learn/)
-- Are you a developer interested in building on OpenRPC? [open-rpc.org/developers](/developers/)
+- Explore the Getting Started Guide. [open-rpc.org/getting-started](/docs/getting-started)
+- Want to get started using OpenRPC? [open-rpc.org/use](/docs/use)
+- Curious to learn more about OpenRPC and its technology? [open-rpc.org/learn](/docs/learn)
+- Are you a developer interested in building on OpenRPC? [open-rpc.org/developers](/docs/developers)
 
 

--- a/src/content/developers.mdx
+++ b/src/content/developers.mdx
@@ -14,7 +14,7 @@ title: OpenRPC Development | Developer guides, resources, and tools for building
 
 #### OpenRPC Tooling Foundations
 
-Need a more basic non-technical primer first? Check out [open-rpc.org/beginners](/beginners).
+Need a more basic non-technical primer first? Check out [open-rpc.org/beginners](/docs/beginners).
 
 ## Specification
 

--- a/src/content/getting-started.mdx
+++ b/src/content/getting-started.mdx
@@ -209,6 +209,6 @@ Here the example JSON-RPC request above is used to provide example data:
 ## Next Steps
 
 - Read the specification. [spec.open-rpc.org](http://spec.open-rpc.org#introduction)
-- Started using OpenRPC [open-rpc.org/use](/use/)
-- Learn more about OpenRPC and its technology [open-rpc.org/learn](/learn/)
-- Build on OpenRPC Tooling [open-rpc.org/developers](/developers/)
+- Started using OpenRPC [open-rpc.org/use](/docs/use)
+- Learn more about OpenRPC and its technology [open-rpc.org/learn](/docs/learn)
+- Build on OpenRPC Tooling [open-rpc.org/developers](/docs/developers)

--- a/src/content/learn.mdx
+++ b/src/content/learn.mdx
@@ -7,11 +7,10 @@ sidebarDepth: 0
 
 # Learn about OpenRPC
 
-**Welcome to [open-rpc.org/learn](/learn/), a set of resources to help you learn more about OpenRPC.** This page includes technical **and** non-technical articles, guides, and resources. If you’re totally new to OpenRPC, [we suggest you start here](/beginners/).
+**Welcome to [open-rpc.org/learn](/docs/learn), a set of resources to help you learn more about OpenRPC.** This page includes technical **and** non-technical articles, guides, and resources. If you're totally new to OpenRPC, [we suggest you start here](/docs/beginners).
 
 Here are some excellent starting points:
-- [OpenRPC Webinar](/webinar/) *open-rpc.org*
-- [OpenRPC Getting Started Guide](/getting-started/) *open-rpc.org*
+- [OpenRPC Getting Started Guide](/docs/getting-started) *open-rpc.org*
 - [ETC Summit 2019 - Day 1 - Talk 05 - Shane Jonas - The Future of JSON RPC Tooling
 ](https://youtu.be/g2zUSyXW6nI?t=59) *ETC Summit*
 - [Who Builds the Building Blocks?](https://hackernoon.com/who-builds-the-building-blocks-9e358d5e0753) *Feb 22, 2019 - Hackernoon*

--- a/src/content/use.mdx
+++ b/src/content/use.mdx
@@ -21,7 +21,7 @@ Navigate to [playground.open-rpc.org](https://playground.open-rpc.org) and start
 
 ### 2. Use the tools with your OpenRPC Document
 
-You can follow the guides [here](/developers/) and use the OpenRPC tools to create:
+You can follow the guides [here](/docs/developers) and use the OpenRPC tools to create:
 
 - API Documentation
 - Clients


### PR DESCRIPTION
## Summary
I found some dead links on your site. 
This is a very naive fix for these links.
Hope you can eighter accept it as is or improve it.

## Changes Made
- ✅ Added `/docs` prefix to all internal documentation links in MDX files (beginners, learn, developers, getting-started, use)
- ✅ Fixed `docsRepositoryBase` in layout.tsx to include `/tree/master` for proper GitHub "Edit this page" functionality
- ✅ Removed unavailable `/webinar/` link from learn.mdx

## Files Modified
- `src/content/beginners.mdx`
- `src/content/learn.mdx`
- `src/content/developers.mdx`
- `src/content/getting-started.mdx`
- `src/content/use.mdx`
- `src/app/layout.tsx`