### PR TITLE
docs: add OpenRPC linter guides

### DIFF
--- a/src/content/_meta.ts
+++ b/src/content/_meta.ts
@@ -1,9 +1,10 @@
 export default {
-  index: 'Introduction',
-  'getting-started': 'Getting Started',
-  use: 'Use Cases',
-  beginners: 'Beginners Guide',
-  developers: 'Developers',
-  learn: 'Learn More',
-  sponsors: 'Sponsors',
-}
+  index: "Introduction",
+  "getting-started": "Getting Started",
+  linter: "OpenRPC Linter",
+  use: "Use Cases",
+  beginners: "Beginners Guide",
+  developers: "Developers",
+  learn: "Learn More",
+  sponsors: "Sponsors",
+};

--- a/src/content/linter/_meta.ts
+++ b/src/content/linter/_meta.ts
@@ -1,0 +1,3 @@
+export default {
+  "rules-and-functions": "Writing Rules and Functions",
+};

--- a/src/content/linter/index.mdx
+++ b/src/content/linter/index.mdx
@@ -1,0 +1,232 @@
+---
+title: OpenRPC Linter | Installation, configuration, and usage
+description: Install, configure, and run the OpenRPC Linter against an OpenRPC document.
+asIndexPage: true
+---
+
+# OpenRPC Linter
+
+The OpenRPC Linter is a fast, extensible command-line tool for checking the
+quality and consistency of OpenRPC documents. It complements specification
+validation with rules for documentation completeness, schema quality,
+usability, and uniqueness.
+
+## Installation
+
+### npm
+
+For JavaScript and TypeScript projects, install the linter as a development
+dependency:
+
+```bash
+npm install --save-dev @open-rpc/openrpc-linter
+```
+
+The npm package installs a native binary for supported macOS, Linux, and
+Windows systems on ARM64 and x64.
+
+### Go
+
+Install the latest release with Go:
+
+```bash
+go install github.com/open-rpc/openrpc-linter@latest
+```
+
+Prebuilt binaries are also available from the
+[GitHub releases page](https://github.com/open-rpc/openrpc-linter/releases).
+
+## Quick start
+
+The linter requires a rules file. Create one that extends the bundled
+`recommended` ruleset:
+
+```bash
+openrpc-linter init
+```
+
+This creates `rules.yml`:
+
+```yaml
+extends:
+  - recommended
+```
+
+Lint an OpenRPC document:
+
+```bash
+openrpc-linter lint openrpc.json --rules rules.yml
+```
+
+If you installed the npm package locally, run the same command with `npx`:
+
+```bash
+npx openrpc-linter lint openrpc.json --rules rules.yml
+```
+
+The linter defaults to `openrpc.json` when the document path is omitted, but it
+does not automatically discover `rules.yml`. Always pass the rules file with
+`--rules` or `-r`.
+
+## Linting and validation
+
+Linting and validation answer different questions:
+
+| Command                                         | Purpose                                              |
+| ----------------------------------------------- | ---------------------------------------------------- |
+| `openrpc-linter lint openrpc.json -r rules.yml` | Applies quality and style rules from a ruleset.      |
+| `openrpc-linter validate openrpc.json`          | Checks the document against the OpenRPC meta-schema. |
+
+Use validation to check specification conformance. Use linting to enforce the
+documentation and design conventions expected by your project.
+
+## The recommended ruleset
+
+The bundled `recommended` ruleset currently contains 23 rules: 8 errors and 15
+warnings. They fall into four broad groups:
+
+| Group                      | Examples                                                                        |
+| -------------------------- | ------------------------------------------------------------------------------- |
+| Documentation completeness | Descriptions, summaries, license information, errors, and examples              |
+| Schema quality             | Schema titles, descriptions, and explicit types or composition keywords         |
+| Usability                  | Non-empty methods and examples, concise summaries, and parameter-count guidance |
+| Uniqueness                 | Method names, summaries, parameter names, error codes, and example names        |
+
+The source of truth is the
+[recommended ruleset](https://github.com/open-rpc/openrpc-linter/blob/main/rules/defaults/recommended.yaml).
+
+## Understanding the results
+
+Text output groups violations by method, schema, descriptor, tag, or top-level
+section. Each result includes a document path, severity, message, and rule ID.
+
+| Severity | Behavior                                                         |
+| -------- | ---------------------------------------------------------------- |
+| `error`  | Reports the violation and makes `lint` exit non-zero.            |
+| `warn`   | Reports the violation without independently failing the command. |
+| `info`   | Reports informational guidance.                                  |
+| `ignore` | Disables the rule.                                               |
+
+For automation, request a flat JSON result:
+
+```bash
+openrpc-linter lint openrpc.json -r rules.yml --format json
+```
+
+## Try a document with known issues
+
+The linter repository includes a
+[fixture with intentional duplicate values](https://github.com/open-rpc/openrpc-linter/blob/main/e2e/fixtures/unique/bad-document.json).
+From a clone of that repository, run:
+
+```bash
+openrpc-linter lint \
+  e2e/fixtures/unique/bad-document.json \
+  --rules rules/defaults/recommended.yaml
+```
+
+With release `v0.0.17`, the command exits non-zero and reports:
+
+```text
+e2e/fixtures/unique/bad-document.json
+
+4 errors, 10 warnings found in 8 rules
+
+  path                                     level    message                                      rule
+
+getBalance
+  methods[0].errors[0].description         warning  missing field 'description'                  error-description
+  methods[0].errors[1].code                error    Duplicate value 1001                         unique-error-codes-per-method
+  methods[0].errors[1].description         warning  missing field 'description'                  error-description
+  methods[0].examples[1].name              error    Duplicate value "basic-request"              unique-example-names-per-method
+  methods[0].params[0].schema.description  warning  missing field 'description'                  schema-description
+    param: "accountId"
+    schema: "Account ID"
+  methods[0].params[1].name                error    Duplicate value "accountId"                  unique-param-names-per-method
+    param: "accountId"
+  methods[0].params[1].schema.description  warning  missing field 'description'                  schema-description
+    param: "accountId"
+    schema: "Account ID (optional)"
+  methods[0].result.schema.description     warning  missing field 'description'                  schema-description
+    schema: "Balance"
+  methods[1].errors[0].description         warning  missing field 'description'                  error-description
+  methods[1].name                          error    Duplicate value "getBalance"                  unique-method-names
+  methods[1].params[0].schema.description  warning  missing field 'description'                  schema-description
+    param: "accountId"
+    schema: "Account ID"
+  methods[1].result.schema.description     warning  missing field 'description'                  schema-description
+    schema: "Balance"
+  methods[1].summary                       warning  Duplicate value "Fetch account balance"      unique-method-summary
+
+info
+  info.license                             warning  missing field 'license'                      info-license
+
+4 errors, 10 warnings found in 8 rules
+```
+
+This run demonstrates that a fixture designed for uniqueness failures can also
+reveal documentation-quality issues when checked against the complete
+recommended ruleset. Exact findings can change as that ruleset evolves.
+
+## Customize the recommended rules
+
+Extend `recommended`, override rules by ID, and add project-specific rules in
+the same file:
+
+```yaml
+extends:
+  - recommended
+
+rules:
+  info-license:
+    severity: ignore
+
+  method-summary:
+    severity: error
+
+  method-name-prefix:
+    description: Method names must begin with rpc_
+    given: $.methods[*].name
+    severity: error
+    then:
+      function: schema
+      functionOptions:
+        type: string
+        pattern: "^rpc_"
+```
+
+See [Writing Rules and Functions](/docs/linter/rules-and-functions) for the
+rule format, selector behavior, built-in functions, and the contributor path
+for adding a new function.
+
+## Add the linter to CI
+
+Add a script to `package.json`:
+
+```json
+{
+  "scripts": {
+    "lint:openrpc": "openrpc-linter lint openrpc.json -r rules.yml"
+  }
+}
+```
+
+Then run it in CI after installing dependencies:
+
+```yaml
+- run: npm ci
+- run: npm run lint:openrpc
+```
+
+## Current boundaries
+
+- OpenRPC documents must be JSON.
+- `lint` currently resolves internal `$ref` references. External references
+  remain unresolved.
+- A rules file must define `extends`, `rules`, or both.
+- `recommended` is currently the only bundled ruleset extension.
+- New executable rule functions must be compiled into the linter; YAML rules
+  can only use registered functions.
+
+The linter is currently pre-1.0. Pin a release in CI when reproducible behavior
+is important.

--- a/src/content/linter/rules-and-functions.mdx
+++ b/src/content/linter/rules-and-functions.mdx
@@ -1,0 +1,282 @@
+---
+title: Writing Rules and Functions | OpenRPC Linter
+description: Build custom OpenRPC Linter rules and contribute new rule functions.
+---
+
+# Writing Rules and Functions
+
+Rules are declarative YAML policies. Functions are compiled Go implementations
+that evaluate the document values selected by those policies. Most projects can
+create useful rules with the built-in functions and do not need to add Go code.
+
+## Anatomy of a rule
+
+```yaml
+rules:
+  method-summary-length:
+    description: Method summaries should be concise
+    given: $.methods[*].summary
+    severity: warn
+    then:
+      function: schema
+      functionOptions:
+        type: string
+        maxLength: 120
+```
+
+| Field                  | Purpose                                               |
+| ---------------------- | ----------------------------------------------------- |
+| `description`          | Explains the policy enforced by the rule.             |
+| `given`                | Selects document locations using JSONPath.            |
+| `severity`             | Sets `error`, `warn`, `info`, or `ignore`.            |
+| `then.function`        | Selects a function registered in the compiled linter. |
+| `then.functionOptions` | Supplies function-specific configuration.             |
+
+## How a rule runs
+
+For each rule, the linter:
+
+1. Parses `given` as JSONPath.
+2. Converts the matches into normalized targets.
+3. Creates one instance of the configured function.
+4. Runs that function once for every selected target.
+5. Adds the rule ID, configured severity, and human-readable location.
+6. Sends the results to the text or JSON reporter.
+
+Selection and reporting live outside the function. Function implementations can
+focus on evaluating one normalized target at a time.
+
+## Selecting targets with `given`
+
+The shape of a JSONPath determines what the function receives:
+
+| Mode             | Example                    | Behavior                                                                         |
+| ---------------- | -------------------------- | -------------------------------------------------------------------------------- |
+| Field            | `$.methods[*].description` | Selects each parent and records whether the named field exists.                  |
+| Value            | `$.methods`                | Passes the selected array or value directly.                                     |
+| Descendant field | `$..schema.description`    | Uses the OpenRPC meta-schema index to find candidates, including missing fields. |
+
+Choose a field path when presence matters. Choose a value path when validating
+the shape, length, or uniqueness of an existing value.
+
+## Built-in functions
+
+### `truthy`
+
+Use `truthy` to require a selected field to exist and contain a non-empty value:
+
+```yaml
+rules:
+  method-description:
+    given: $.methods[*].description
+    severity: error
+    then:
+      function: truthy
+```
+
+`nil`, an empty string, and the string `"null"` fail this check.
+
+### `schema`
+
+Use `schema` for constraints expressible with JSON Schema:
+
+```yaml
+rules:
+  method-summary-length:
+    given: $.methods[*].summary
+    severity: warn
+    then:
+      function: schema
+      functionOptions:
+        type: string
+        maxLength: 120
+```
+
+`functionOptions` is the schema itself. Missing fields are skipped, so pair
+`schema` with a `truthy` rule when the field is also required.
+
+### `unique`
+
+Use `unique` for primitive values that must not repeat:
+
+```yaml
+rules:
+  unique-param-names-per-method:
+    given: $.methods[*].params[*].name
+    severity: error
+    then:
+      function: unique
+      functionOptions:
+        scope: $.methods[*]
+```
+
+Without `scope`, values are compared globally. With `scope`, values are compared
+inside the longest matching scope. Strings, numbers, booleans, and null are
+supported.
+
+## Decide whether a new function is necessary
+
+Before adding Go code, check whether the requirement can use:
+
+1. `schema` for types, patterns, lengths, ranges, arrays, or object shape.
+2. `truthy` for required non-empty fields.
+3. `unique` for duplicate detection, optionally within a scope.
+
+A new function is appropriate for a check that needs bespoke computation or a
+relationship between document locations that these functions cannot express.
+
+## Function interface
+
+Every function implements `RuleFunction`:
+
+```go
+type RuleFunction interface {
+    RunRule(
+        value interface{},
+        context RuleFunctionContext,
+    ) []RuleFunctionResult
+}
+```
+
+`value` is the selected value for the current invocation. The context exposes
+the rule, rule ID, original document, internally resolved document, normalized
+target, and target path.
+
+A function returns no results when the value passes. A result with a message is
+a violation:
+
+```go
+return []types.RuleFunctionResult{
+    {
+        Message: "value does not satisfy the rule",
+    },
+}
+```
+
+The executor fills in the selected path when the function does not provide one,
+then applies the configured severity and rule ID.
+
+## Add a function
+
+The following deliberately small example illustrates the contributor workflow.
+The same prefix check can already be expressed with `schema`, so it would not by
+itself justify a new built-in function.
+
+Create a function in the `functions` package:
+
+```go
+package functions
+
+import (
+    "fmt"
+    "strings"
+
+    "github.com/open-rpc/openrpc-linter/types"
+)
+
+type StartsWithRule struct{}
+
+func (r *StartsWithRule) RunRule(
+    value interface{},
+    context types.RuleFunctionContext,
+) []types.RuleFunctionResult {
+    target := context.Target
+
+    // Let a separate truthy rule report missing fields.
+    if target != nil && target.Field != "" && !target.Exists {
+        return nil
+    }
+
+    prefix, ok := context.Rule.Then.FunctionOptions["prefix"].(string)
+    if !ok || prefix == "" {
+        return []types.RuleFunctionResult{{
+            Message: "startsWith requires a non-empty prefix option",
+        }}
+    }
+
+    text, ok := value.(string)
+    if !ok {
+        return []types.RuleFunctionResult{{
+            Message: "startsWith requires a string value",
+        }}
+    }
+
+    if strings.HasPrefix(text, prefix) {
+        return nil
+    }
+
+    return []types.RuleFunctionResult{{
+        Message: fmt.Sprintf("value must start with %q", prefix),
+    }}
+}
+```
+
+### Register the function
+
+Add one factory entry to `RegisterFunctions`:
+
+```go
+FunctionRegistry["startsWith"] = func() types.RuleFunction {
+    return &StartsWithRule{}
+}
+```
+
+The YAML function name must match this registry key exactly. The factory creates
+one function instance per rule, which lets stateful implementations such as
+`unique` retain state across that rule's targets without leaking it into another
+rule.
+
+No deeper registry knowledge is required to contribute a function.
+
+### Build a rule on the function
+
+```yaml
+rules:
+  method-name-prefix:
+    description: Method names must begin with rpc_
+    given: $.methods[*].name
+    severity: error
+    then:
+      function: startsWith
+      functionOptions:
+        prefix: rpc_
+```
+
+An unregistered function name produces an `unknown function` error.
+
+## Test a function contribution
+
+Tests should cover:
+
+- A passing value produces no violation.
+- A failing value produces a useful message.
+- Missing fields behave intentionally.
+- Invalid or missing options produce useful diagnostics.
+- Stateful checks do not leak data between rules.
+- An end-to-end YAML rule selects and reports the expected document path.
+
+Run the test suite:
+
+```bash
+go test ./...
+```
+
+## Propose a recommended rule
+
+Adding a function does not enable it automatically. Project-specific rules can
+use any registered function without changing the bundled preset.
+
+To propose a rule for all users:
+
+1. Add it to
+   [`rules/defaults/recommended.yaml`](https://github.com/open-rpc/openrpc-linter/blob/main/rules/defaults/recommended.yaml).
+2. Choose an intentional default severity.
+3. Add passing and failing end-to-end scenarios.
+4. Document the policy, selected locations, and remediation.
+
+The relevant implementation references are
+[`types/types.go`](https://github.com/open-rpc/openrpc-linter/blob/main/types/types.go),
+[`rules/rules.go`](https://github.com/open-rpc/openrpc-linter/blob/main/rules/rules.go),
+[`selector/select.go`](https://github.com/open-rpc/openrpc-linter/blob/main/selector/select.go),
+and
+[`functions/registry.go`](https://github.com/open-rpc/openrpc-linter/blob/main/functions/registry.go).


### PR DESCRIPTION
## Summary

- add an OpenRPC Linter category to the website documentation
- document installation, quick start, linting versus validation, the recommended ruleset, CI usage, and current limitations
- include a reproducible run against the linter repository's known-bad fixture with representative output
- add a developer guide for composing rules with built-in functions and contributing new functions

## Verification

- `bun run build` passes and prerenders both new linter routes
- Prettier passes for all changed files
- repository-wide ESLint still reports pre-existing errors in generated Pagefind assets and existing application code; it reports no new MDX errors